### PR TITLE
Switch internal doc links from absolute to relative

### DIFF
--- a/docs/concepts/customers.md
+++ b/docs/concepts/customers.md
@@ -2,11 +2,11 @@
 
 In Planship, a customer represents a customer of your product. It can be an individual, another business, or anything else that makes sense for your business.
 
-Once you [register a customer](/integration/customers) with Planship, you can [subscribe them to plans](/integration/subscriptions), [report and track their usage](/integration/usage), and [retrieve feature and usage entitlements](/integration/entitlements).
+Once you [register a customer](../integration/customers.md) with Planship, you can [subscribe them to plans](../integration/subscriptions.md), [report and track their usage](../integration/usage.md), and [retrieve feature and usage entitlements](../integration/entitlements.md).
 
 ## Customer attributes
 
-When you [register a customer with Planship](/integration/customers), you can optionally provide their _name_, _email_, _metadata_ and an _alternative ID_. If you'd rather not store any customer data in Planship, you can leave them empty.
+When you [register a customer with Planship](../integration/customers.md), you can optionally provide their _name_, _email_, _metadata_ and an _alternative ID_. If you'd rather not store any customer data in Planship, you can leave them empty.
 
 ## Using an alternative customer ID
 

--- a/docs/concepts/feature-levers.md
+++ b/docs/concepts/feature-levers.md
@@ -1,6 +1,6 @@
 # Feature levers
 
-Feature levers allow or limit access to certain features of your product according to a customer's subscription plan. In Planship, this is accomplished by the combination of _levers_ that define features and default values and [_entitlements_](/concepts/plans/#entitlements) that specify specific limits or allowances for these levers on individal plans.
+Feature levers allow or limit access to certain features of your product according to a customer's subscription plan. In Planship, this is accomplished by the combination of _levers_ that define features and default values and [_entitlements_](plans.md#entitlements) that specify specific limits or allowances for these levers on individal plans.
 
 !!! Example
     Imagine a product that does parallel processing of customer data, where different pricing tiers offer different levels of processing concurrency. To accomplish this with Planship, you would define an *execution-concurrency* lever and then create entitlements that specify desired *execution-concurrency* values on different plans (E.g. `1`, `10`, and `100` on "Free," "Personal," and "Business" plans respectively).
@@ -30,7 +30,7 @@ A simple flag to indicate whether a given feature is available on a given plan o
 
 #### Integer
 
-Integer levers represent numerical features and are useful for defining limits on **unmetered** product resources ([For handling **metered** product resources, see _metered levers_](/concepts/metered-levers)). In addition to the *default value*, the following configuration options are available:
+Integer levers represent numerical features and are useful for defining limits on **unmetered** product resources ([For handling **metered** product resources, see _metered levers_](metered-levers.md)). In addition to the *default value*, the following configuration options are available:
 
 - *min* - minimum allowed entitlement value (default: 0)
 - *max* - maxium allowed entitlement value (default: 100)

--- a/docs/concepts/feature-levers.md
+++ b/docs/concepts/feature-levers.md
@@ -35,7 +35,7 @@ Integer levers represent numerical features and are useful for defining limits o
 - *min* - minimum allowed entitlement value (default: 0)
 - *max* - maxium allowed entitlement value (default: 100)
 - *step* - entitlement value step increment (default: 0)
-- *infinite* - value that represents an inifinite entitlement value (default: -1)
+- *infinite* - value that represents an infinite entitlement value (default: -1)
 
 #### List
 

--- a/docs/concepts/metered-levers.md
+++ b/docs/concepts/metered-levers.md
@@ -1,20 +1,20 @@
 # Metered levers
 
-Metered levers (Also known as usage-based, consumption-based, or pay-as-you-go pricing) track usage and set limits on the metered resources of your product according to customers' subscription plans. In Planship, metered levers define the usage that's tracked and how it's aggregated, and [entitlements](/concepts/plans/#entitlements) limit that usage on specific plans.
+Metered levers (Also known as usage-based, consumption-based, or pay-as-you-go pricing) track usage and set limits on the metered resources of your product according to customers' subscription plans. In Planship, metered levers define the usage that's tracked and how it's aggregated, and [entitlements](plans.md#entitlements) limit that usage on specific plans.
 
 !!! Example
     Imagine a product that offers subscription plans priced according to monthly API call volume. It offers up to 1, 2, and 5 million API calls per month on "Free," "Personal," and "Business" plans respectively. To accomplish this with Planship, you'd define a metered lever named *api-call* that aggregates the total reported usage over a subscription period of one month, and then create entitlements on each plan that specifies the desired *api-call* limit (1 million on Free, 2 million on Personal, and 5 million on Business).
 
 !!! tip "Pay-as-you-go"
-    If you simply want to meter usage and don't need to enforce any sort of limiting on the usage, you can do so by defining a metered lever with a [default limit](/concepts/metered-levers/#default-limit) of `-1` (inifinite) and reporting usage without defining explicit entitlements.
+    If you simply want to meter usage and don't need to enforce any sort of limiting on the usage, you can do so by defining a metered lever with a [default limit](metered-levers.md#default-limit) of `-1` (inifinite) and reporting usage without defining explicit entitlements.
 
 ## Usage reporting
 
-In order for usage to be tracked and aggregated, it has to be [reported to Planship via the API](/integration/usage#report-usage). A single usage-report API call carries information about the customer, the amount of usage, and the *metering ID* that identifies the product resource being consumed. It results in the creation of a single, traceable metering record.
+In order for usage to be tracked and aggregated, it has to be [reported to Planship via the API](../integration/usage.md#report-usage). A single usage-report API call carries information about the customer, the amount of usage, and the *metering ID* that identifies the product resource being consumed. It results in the creation of a single, traceable metering record.
 
 ### Usage buckets
 
-Usage buckets allow grouping of usage within a single metering ID. [Bucket names are specified when reporting usage to Planship via the API](/integration/usage#reporting-bucketed-usage), and bucket-name tracking enables more complex usage aggregation scenarios.
+Usage buckets allow grouping of usage within a single metering ID. [Bucket names are specified when reporting usage to Planship via the API](../integration/usage.md#reporting-bucketed-usage), and bucket-name tracking enables more complex usage aggregation scenarios.
 
 !!! Example
     Suppose you have a product that allows customers to create projects. Within these projects, they can make API calls, which are limited by their plan. While API calls are aggregated across all projects, it may be useful to also track these API calls by the project that generated them. In this case, you'd report usage along with a bucket name corresponding to the project that generated it.
@@ -65,7 +65,7 @@ The aggregation formula defines how usage is aggregated. It should be set to the
 - *Unique buckets* - count unique bucket names across metering records
 
 !!! Example
-    Imagine a product where pricing is based on monthly active API users. To accomplish this with Planship, you could define a *monthly-active-users* metered lever that uses the *unique buckets* formula and tracks a metering ID called *api-call*. The product would then [report API calls to Planship](/integration/usage#reporting-bucketed-usage) along with a unique user identifier (E.g. ID or email address) passed as *bucket*.
+    Imagine a product where pricing is based on monthly active API users. To accomplish this with Planship, you could define a *monthly-active-users* metered lever that uses the *unique buckets* formula and tracks a metering ID called *api-call*. The product would then [report API calls to Planship](../integration/usage.md#reporting-bucketed-usage) along with a unique user identifier (E.g. ID or email address) passed as *bucket*.
 
 #### Period
 
@@ -77,7 +77,7 @@ The aggregation period defines the time boundary for aggregation of metering rec
 
 #### Scope
 
-Scope defines whether usage should be aggregated per customer or per subscription, which can include multiple customers. By default, the aggregation scope is set to the subscription level. Changing the aggregation scope is meaningful only in [team subscriptions](/concepts/plans#individual-vs-team-subscriptions).
+Scope defines whether usage should be aggregated per customer or per subscription, which can include multiple customers. By default, the aggregation scope is set to the subscription level. Changing the aggregation scope is meaningful only in [team subscriptions](plans.md#individual-vs-team-subscriptions).
 
 !!! Example
-    Imagine a file processing service with pricing tiers that limit the number of files uploaded by individual team members (I.e. subscription customers) per day as well as the number of seats per subscription. To implement this in Planship, you could define a _files-per-customer_ metered lever that tracks a *file-upload* metering ID, and aggregate it using the _total usage_ per day (_custom_ period) formula with a per-customer aggregation scope. The seat limit would be defined in the [plan configuration](/concepts/plans#subscriber-limits-teams-and-seats).
+    Imagine a file processing service with pricing tiers that limit the number of files uploaded by individual team members (I.e. subscription customers) per day as well as the number of seats per subscription. To implement this in Planship, you could define a _files-per-customer_ metered lever that tracks a *file-upload* metering ID, and aggregate it using the _total usage_ per day (_custom_ period) formula with a per-customer aggregation scope. The seat limit would be defined in the [plan configuration](plans.md#subscriber-limits-teams-and-seats).

--- a/docs/concepts/metered-levers.md
+++ b/docs/concepts/metered-levers.md
@@ -6,7 +6,7 @@ Metered levers (Also known as usage-based, consumption-based, or pay-as-you-go p
     Imagine a product that offers subscription plans priced according to monthly API call volume. It offers up to 1, 2, and 5 million API calls per month on "Free," "Personal," and "Business" plans respectively. To accomplish this with Planship, you'd define a metered lever named *api-call* that aggregates the total reported usage over a subscription period of one month, and then create entitlements on each plan that specifies the desired *api-call* limit (1 million on Free, 2 million on Personal, and 5 million on Business).
 
 !!! tip "Pay-as-you-go"
-    If you simply want to meter usage and don't need to enforce any sort of limiting on the usage, you can do so by defining a metered lever with a [default limit](metered-levers.md#default-limit) of `-1` (inifinite) and reporting usage without defining explicit entitlements.
+    If you simply want to meter usage and don't need to enforce any sort of limiting on the usage, you can do so by defining a metered lever with a [default limit](metered-levers.md#default-limit) of `-1` (infinite) and reporting usage without defining explicit entitlements.
 
 ## Usage reporting
 

--- a/docs/concepts/plans.md
+++ b/docs/concepts/plans.md
@@ -2,7 +2,7 @@
 
 In Planship, a plan represents a single pricing offering of your product. A Planship plan can represent one of the tiers of a multi-tier pricing model, a one-off package that never expires, a temporary add-on to a recurring subscription plan, or anything in between.
 
-A plan has a subscription period, renewal rules, subscriber limits, and a set of [***entitlements***](#entitlements) that define how various [*feature*](/concepts/feature-levers) and [*metered*](/concepts/metered-levers) pricing levers are applied to customers of the plan.
+A plan has a subscription period, renewal rules, subscriber limits, and a set of [***entitlements***](#entitlements) that define how various [*feature*](feature-levers.md) and [*metered*](metered-levers.md) pricing levers are applied to customers of the plan.
 
 Customers can subscribe to a plan either by creating a new subscription or by joining an existing subscription (I.e. a team account).
 
@@ -16,7 +16,7 @@ Each plan has a subscription duration and renewal configuration. This configurat
 
 ## Entitlements
 
- Entitlements define how various product [feature](/concepts/feature-levers) and [metered](/concepts/metered-levers) levers apply to a plan. They're used to determine what a customer on a subscription to a plan can and can't do at a point in time. If an explict entitlement to a lever isn't defined, the default value defined on the lever is applied as an implicit entitlement.
+ Entitlements define how various product [feature](feature-levers.md) and [metered](metered-levers.md) levers apply to a plan. They're used to determine what a customer on a subscription to a plan can and can't do at a point in time. If an explict entitlement to a lever isn't defined, the default value defined on the lever is applied as an implicit entitlement.
 
 ## Subscriber limits (teams and seats)
 

--- a/docs/concepts/products.md
+++ b/docs/concepts/products.md
@@ -1,6 +1,6 @@
 ## Products
 
-In Planship, a product is a container that defines pricing [plans](/concepts/plans) along with [feature](/concepts/feature-levers) and [metered](/concepts/metered-levers) levers, and it typically represents a single product offering for your customers. However, a Planship product can also represent a part of a larger product, a group of products, or whatever makes sense for your business.
+In Planship, a product is a container that defines pricing [plans](plans.md) along with [feature](feature-levers.md) and [metered](metered-levers.md) levers, and it typically represents a single product offering for your customers. However, a Planship product can also represent a part of a larger product, a group of products, or whatever makes sense for your business.
 
 !!! Example
     Imagine a large product that is marketed as a single solution and is built on a single tech stack, but in reality consists of several distinct offerings that are priced independently of one another.
@@ -11,7 +11,7 @@ Every product has a unique _name_, which is used to automatically generate a _sl
 
 ## Organizations
 
-An organization is a top level container for your Planship products and [customers](/concepts/customers), and it typically represents your business or a part of it (E.g. a division of a larger company).
+An organization is a top level container for your Planship products and [customers](customers.md), and it typically represents your business or a part of it (E.g. a division of a larger company).
 
 ## Users
 

--- a/docs/howtos/console-step-by-step.md
+++ b/docs/howtos/console-step-by-step.md
@@ -23,9 +23,9 @@ With the plans defined above, we can identify three pricing dimensions of our pr
 
 Understanding the dimensions is critical because they directly correspond to Planship feature and metered levers. In turn, correctly defined Planship levers will enable us to apply appropriate entitlements to various plans, and enforce these entitlements in our product code. The dimensions that we identified will map to the following Planship levers.
 
-1. **Integrations** - [feature lever](/concepts/feature-levers) of *list* type
-2. **Notifications per period** - [metered lever](/concepts/metered-levers) with *total usage per subscription period* aggregation formula
-2. **Notification max characters** - [feature lever](/concepts/feature-levers) of *integer* type
+1. **Integrations** - [feature lever](../concepts/feature-levers.md) of *list* type
+2. **Notifications per period** - [metered lever](../concepts/metered-levers.md) with *total usage per subscription period* aggregation formula
+2. **Notification max characters** - [feature lever](../concepts/feature-levers.md) of *integer* type
 
 ## Creating a new product
 
@@ -34,11 +34,11 @@ Let's start by signing into the [Planship Console](https://app.planship.io/auth/
 Once signed in, navigate to the desired organization (E.g. the default organization automatically created by Planship) by clicking on it. Then create a new product by clicking the *New product* button. Give the new product a name (E.g. 'My product'), and click the *Create* button to save it.
 
 <figure markdown="span">
-  ![Planship console screenshot showing a new product creation using `Create a product` dialog ](/assets/screenshots/01-create-new-product.png){ width="600" }
+  ![Planship console screenshot showing a new product creation using `Create a product` dialog ](../assets/screenshots/01-create-new-product.png){ width="600" }
   <figcaption>Create a new product</figcaption>
 </figure>
 
-The name that we choose for our new product is important as Planship will use it to generate a product `slug` (E.g. 'My product' -> `my-product`). The product `slug` is the unique identifer of a product in Planship API operations.  For instance, we will use it to identify the product when [initializing the Planship API client](/integration/#getting-started-with-planship-sdks).
+The name that we choose for our new product is important as Planship will use it to generate a product `slug` (E.g. 'My product' -> `my-product`). The product `slug` is the unique identifer of a product in Planship API operations.  For instance, we will use it to identify the product when [initializing the Planship API client](../integration/index.md#getting-started-with-planship-sdks).
 
 !!!note
     The Planship API uses `slugs` to identify resources like `products`, `plans`, and `levers`, and they are unique within the scope of their parent and type. Please note that changing a `product`, `plan`, or `lever` name will result in a change of its `slug`, which will likely break your existing Planship SDK integration unless a refactor is performed.
@@ -54,17 +54,17 @@ The new product is empty; it has no plans or levers defined in it. Let's start b
 On the product page, switch to the *Levers* tab, and click the *New lever* button. This will open the *Create a lever* dialog. Enter a name for the new lever (*Integrations*), and select *List* as the lever type.
 
 !!!note
-    Just like the product, the new lever's name will be used by Planship to generate a `slug` that will become the unique identifier for it in Planship API operations. For instance, lever slugs are used as keys in the [entitlements dictionary returned by Planship](/integration/entitlements).
+    Just like the product, the new lever's name will be used by Planship to generate a `slug` that will become the unique identifier for it in Planship API operations. For instance, lever slugs are used as keys in the [entitlements dictionary returned by Planship](../integration/entitlements.md).
 
 <figure markdown="span">
-  ![Planship console screenshot showing a new 'Integrations' list lever creation using the `Create a lever` dialog ](/assets/screenshots/03-create-levers-integrations-2.png){ width="600" }
+  ![Planship console screenshot showing a new 'Integrations' list lever creation using the `Create a lever` dialog ](../assets/screenshots/03-create-levers-integrations-2.png){ width="600" }
   <figcaption>Create 'Integrations' lever</figcaption>
 </figure>
 
-Now it's time to configure the values for the new lever. We chose the [*list feature* type](/concepts/feature-levers/#list) for this **Integrations** lever because it maps to a product feature best represented by a list of strings (E.g. `['Email', 'Slack']` if both *Email* and *Slack* integrations are available to a customer). Add all supported values (*Email*, *Slack*, and *SMS*) to the *Items* field, and optionally choose items for the lever's *Default value*. The default value is applied automatically to all plans without an explicit entitlement that overrides it.
+Now it's time to configure the values for the new lever. We chose the [*list feature* type](../concepts/feature-levers.md#list) for this **Integrations** lever because it maps to a product feature best represented by a list of strings (E.g. `['Email', 'Slack']` if both *Email* and *Slack* integrations are available to a customer). Add all supported values (*Email*, *Slack*, and *SMS*) to the *Items* field, and optionally choose items for the lever's *Default value*. The default value is applied automatically to all plans without an explicit entitlement that overrides it.
 
 <figure markdown="span">
-  ![Planship console screenshot showing the 'Integrations' list lever configuration using `Create a lever` dialog ](/assets/screenshots/04-create-levers-integrations-3.png){ width="600" }
+  ![Planship console screenshot showing the 'Integrations' list lever configuration using `Create a lever` dialog ](../assets/screenshots/04-create-levers-integrations-3.png){ width="600" }
   <figcaption>Configure the 'Integrations' lever's items and default value</figcaption>
 </figure>
 
@@ -72,10 +72,10 @@ Click the *Create* button to save the new **Integrations** lever, and click the 
 
 ### **Notifications per period** metered usage lever
 
-This time, after choosing a name for the new lever (*Notifications per period*), we are going to pick *Metered* as its type. Leave all configuration fields set to their default values, with the exception of the *Metering Identifiers* field, where we are going to enter *notification*. In Planship, a *Metering ID* is an arbitrary string that identifies a unit of raw usage reported to Planship. You can read more about *Metering IDs* [here](/concepts/metered-levers/#metering-id).
+This time, after choosing a name for the new lever (*Notifications per period*), we are going to pick *Metered* as its type. Leave all configuration fields set to their default values, with the exception of the *Metering Identifiers* field, where we are going to enter *notification*. In Planship, a *Metering ID* is an arbitrary string that identifies a unit of raw usage reported to Planship. You can read more about *Metering IDs* [here](../concepts/metered-levers.md#metering-id).
 
 <figure markdown="span">
-  ![Planship console screenshot showing the 'Notifications per period' metered lever creation using the `Create a lever` dialog ](/assets/screenshots/05-create-levers-notifications.png){ width="600" }
+  ![Planship console screenshot showing the 'Notifications per period' metered lever creation using the `Create a lever` dialog ](../assets/screenshots/05-create-levers-notifications.png){ width="600" }
   <figcaption>Create and configure the 'Notifications per period' metered lever</figcaption>
 </figure>
 
@@ -86,14 +86,14 @@ Click the **Create** button to save changes, and repeat the process for the rema
 Click the **New lever** button, choose a lever name (*Notifications max characters*), and pick *Integer* for its type. This lever represents a numerical limit that we may want enforce in our product code. We are going to leave all of the configuration fields set to their defaults except for the *Default value*, which we'll set to 120.
 
 <figure markdown="span">
-  ![Planship console screenshot showing 'Notifications max characters' integer lever creation using `Create a lever` dialog ](/assets/screenshots/06-create-levers-characters.png){ width="600" }
+  ![Planship console screenshot showing 'Notifications max characters' integer lever creation using `Create a lever` dialog ](../assets/screenshots/06-create-levers-characters.png){ width="600" }
   <figcaption>Create and configure the 'Notifications max characters' integer lever</figcaption>
 </figure>
 
 Click the *Create* button to save changes. Now we're ready to define plans and configure entitlements.
 
 <figure markdown="span">
-  ![Planship console screenshot showing product 'Levers' tab with three different levers ](/assets/screenshots/06-all-levers.png){ width="600" }
+  ![Planship console screenshot showing product 'Levers' tab with three different levers ](../assets/screenshots/06-all-levers.png){ width="600" }
   <figcaption>All levers defined for the 'My product' product</figcaption>
 </figure>
 
@@ -104,7 +104,7 @@ Switch to the *Plans* tab, and click the *New plan* button. Enter *'Free'* as th
 ### **Free** plan
 
 <figure markdown="span">
-  ![Planship console screenshot showing the 'Create a plan' dialog ](/assets/screenshots/07-create-free-plan.png){ width="600" }
+  ![Planship console screenshot showing the 'Create a plan' dialog ](../assets/screenshots/07-create-free-plan.png){ width="600" }
   <figcaption>Create 'Free' plan</figcaption>
 </figure>
 
@@ -115,28 +115,28 @@ We should now see the *Entitlements* tab of the newly created **Free** plan. Sin
 - **Notifications per period**: `0`
 
 <figure markdown="span">
-  ![Planship console screenshot showing initial entitlements for the new 'Free' plan](/assets/screenshots/08-create-free-plan-implicit-entitlements.png){ width="600" }
+  ![Planship console screenshot showing initial entitlements for the new 'Free' plan](../assets/screenshots/08-create-free-plan-implicit-entitlements.png){ width="600" }
   <figcaption>Initial entitlements for the 'Free' plan</figcaption>
 </figure>
 
 While the **Integrations** and **Notification max characters** entitlement values are identical to what we intended for the **Free** plan, **Notifications per period** entitlement value is not; it should be `5` notificatons per period instead of `0`. To change the value we need to to create an *explicit* entitlement for the **Notifications per period** lever.
 
 <figure markdown="span">
-  ![Planship console screenshot showing creation of an explicit entitlement for the **Notifications per period** lever](/assets/screenshots/09-create-free-plan-explicit-entitlement.png){ width="600" }
+  ![Planship console screenshot showing creation of an explicit entitlement for the **Notifications per period** lever](../assets/screenshots/09-create-free-plan-explicit-entitlement.png){ width="600" }
   <figcaption>Create an explicit entitlement for the Notifications per period lever</figcaption>
 </figure>
 
 Click the **Notifications per period** implicit entitlement to open the *Create an explicit entitlement* dialog, change the *Usage limit* value to `5`, and click the *Create* button to save the entitlement.
 
 <figure markdown="span">
-  ![Planship console screenshot showing explicit and implicit entitlements of the 'Free' plan](/assets/screenshots/10-create-free-plan-final-entitlements.png){ width="600" }
+  ![Planship console screenshot showing explicit and implicit entitlements of the 'Free' plan](../assets/screenshots/10-create-free-plan-final-entitlements.png){ width="600" }
   <figcaption>Fully configured entititlements of the 'Free' plan</figcaption>
 </figure>
 
 Before we move on to create and configure our two remaining plans, let's make sure that the **Free** plan has correct subscription renewal settings. Switch to the *Settings* tab and review the value of the *Auto renew*, *Auto renew plan*, and *Duration* fields. By default, they should be set to `True`, `Free`, and `1 month` respectively. This means that all subscriptions to this plan will automatically renew to the **Free** plan every month unless they are configured otherwise.
 
 <figure markdown="span">
-  ![Planship console screenshot showing the settings tab of the 'Free' plan](/assets/screenshots/14-free-plan-settings.png){ width="600" }
+  ![Planship console screenshot showing the settings tab of the 'Free' plan](../assets/screenshots/14-free-plan-settings.png){ width="600" }
   <figcaption>Settings tab of the 'Free' plan</figcaption>
 </figure>
 
@@ -145,24 +145,24 @@ Before we move on to create and configure our two remaining plans, let's make su
 Click the *New plan* button to repeat the process for the **Personal** plan. The **Personal** plan should include both *Email* and *Slack* integrations, up to 50 notifications per subscription, and a 240 character limit.
 
 <figure markdown="span">
-  ![Planship console screenshot showing creation of an explicit entitlement for the **Integrations** lever](/assets/screenshots/11-personal-plan-create-integrations-entitlement.png){ width="600" }
+  ![Planship console screenshot showing creation of an explicit entitlement for the **Integrations** lever](../assets/screenshots/11-personal-plan-create-integrations-entitlement.png){ width="600" }
   <figcaption>Create an explicit entitlement for the 'Integrations' lever</figcaption>
 </figure>
 
 To accomplish this, we need to replace the plan's implicit entitlements (default values) with explicit ones. Let's start with the **Integrations** lever by clicking on its implicit entitlement, or the *New entitlement* button and choosing *Integrations* from the list. Then, select the **Integrations** values that should be supported on the **Personal** plan (*Email* and *Slack*), and click the *Create* button to save your changes.
 
 <figure markdown="span">
-  ![Planship console screenshot showing explicit entitlements of the **Personal** plan](/assets/screenshots/12-personal-plan-entitlements.png){ width="600" }
+  ![Planship console screenshot showing explicit entitlements of the **Personal** plan](../assets/screenshots/12-personal-plan-entitlements.png){ width="600" }
   <figcaption>Fully configured entititlements of the 'Personal' plan</figcaption>
 </figure>
 
 Repeat the process for the remaining two levers until all entitlements match the desired values for the **Personal** plan, and follow the same steps to create the **Team** plan with the desired entitlements.
 
 <figure markdown="span">
-  ![Planship console screenshot showing explicit entitlements of the **Team** plan](/assets/screenshots/13-team-plan-entitlements.png){ width="600" }
+  ![Planship console screenshot showing explicit entitlements of the **Team** plan](../assets/screenshots/13-team-plan-entitlements.png){ width="600" }
   <figcaption>Fully configured entititlements of the 'Team' plan</figcaption>
 </figure>
 
 ## Next steps
 
-With our new product fully defined including levers, plans, and plan entitlements, we can now register customers, subscribe them to plans, retrieve entitlements, and more through the Planship SDK of our choosing. To get started, check out the [Planship code integration guide](/integration/#step-2-integrate-planship-into-your-product-code).
+With our new product fully defined including levers, plans, and plan entitlements, we can now register customers, subscribe them to plans, retrieve entitlements, and more through the Planship SDK of our choosing. To get started, check out the [Planship code integration guide](../integration/index.md#step-2-integrate-planship-into-your-product-code).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,11 @@ Planship enables you to quickly build subscription-related logic that scales wit
 
 **1. Define pricing levers and plans**
 
-Identify your product's pricing levers: [features](/concepts/feature-levers), [metered usage](/concepts/metered-levers), and/or [seats](/concepts/plans/#subscriber-limits-teams-and-seats). Define them with the [Planship console](https://app.planship.io) and connect them to your plans via [entitlements](/concepts/plans/#entitlements).
+Identify your product's pricing levers: [features](concepts/feature-levers.md), [metered usage](concepts/metered-levers.md), and/or [seats](concepts/plans.md#subscriber-limits-teams-and-seats). Define them with the [Planship console](https://app.planship.io) and connect them to your plans via [entitlements](concepts/plans.md#entitlements).
 
 **2. Instrument your code**
 
-Use the [Planship SDK](/integration/#getting-started-with-planship-sdks) of your choice to fetch entitlement data, report metered usage, register new customers, and manage their plan subscriptions. Once complete, the only time you'll need to instrument your code again is when adding a quick entitlement check for a new pricing lever or emitting a new usage metric.
+Use the [Planship SDK](integration/index.md#getting-started-with-planship-sdks) of your choice to fetch entitlement data, report metered usage, register new customers, and manage their plan subscriptions. Once complete, the only time you'll need to instrument your code again is when adding a quick entitlement check for a new pricing lever or emitting a new usage metric.
 
 **3. Iterate on pricing and manage customers**
 

--- a/docs/integration/customers.md
+++ b/docs/integration/customers.md
@@ -1,4 +1,4 @@
-Registering a [customer](/concepts/customers) with Planship enables your product to do the following:
+Registering a [customer](../concepts/customers.md) with Planship enables your product to do the following:
 
  - Subscribe/unsubscribe customers to Planship plans
  - Retrieve feature and metered entitlements for a customer

--- a/docs/integration/entitlements.md
+++ b/docs/integration/entitlements.md
@@ -1,4 +1,4 @@
-Once a customer is [registered with Planship](/integration/customers) and [subscribed to one or more Planship plans](/integration/subscriptions), you can check their entitlements.
+Once a customer is [registered with Planship](customers.md) and [subscribed to one or more Planship plans](subscriptions.md), you can check their entitlements.
 
 === "JavaScript"
 
@@ -86,7 +86,7 @@ Entitlements are returned as a dictionary containing all feature and metered ent
 
 !!!note
 
-    Metered lever entitlement values represent the amount of metered usage available to a customer. For instance, if a customer has a limit of 100 SMS messages per subscription period, and they've already used 25 messages in the current period, the entitlements value for the lever (`subscription-sms-messages`) will be 75. If you'd like to get the current usage for a customer, see [`getLeverUsage`](/integration/usage/#check-current-usage).
+    Metered lever entitlement values represent the amount of metered usage available to a customer. For instance, if a customer has a limit of 100 SMS messages per subscription period, and they've already used 25 messages in the current period, the entitlements value for the lever (`subscription-sms-messages`) will be 75. If you'd like to get the current usage for a customer, see [`getLeverUsage`](usage.md#check-current-usage).
 
 ### Receiving entitlements via a WebSocket connection
 

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -6,27 +6,27 @@ To get started, sign into the [Planship Console](https://app.planship.io/auth/si
 
 In the console, you'll do the following:
 
-- Create a [product](/concepts/products) that corresponds to your software product
-- Create [feature](/concepts/feature-levers) and/or [metered](/concepts/metered-levers) levers that map to the pricing dimensions of your product.
-- Create [plans](/concepts/plans) that map to your recurring subscription plans, one-off packages, add-ons, etc.
-- Apply pricing levers to individual plans by defining [entitlements](/concepts/plans/#entitlements).
+- Create a [product](../concepts/products.md) that corresponds to your software product
+- Create [feature](../concepts/feature-levers.md) and/or [metered](../concepts/metered-levers.md) levers that map to the pricing dimensions of your product.
+- Create [plans](../concepts/plans.md) that map to your recurring subscription plans, one-off packages, add-ons, etc.
+- Apply pricing levers to individual plans by defining [entitlements](../concepts/plans.md#entitlements).
 
 !!!tip "Want guidance?"
-    If you're new to Planship, you can follow our [Planship Console walkthrough HOWTO guide](/howtos/console-step-by-step) for a step-by-step guide on creating products, plans, levers, and entitlements.
+    If you're new to Planship, you can follow our [Planship Console walkthrough HOWTO guide](../howtos/console-step-by-step.md) for a step-by-step guide on creating products, plans, levers, and entitlements.
 
 <figure markdown="span">
-  ![Plans view of the Planship app showing a list of plans along with the details of the selected plan named 'Personal'](/assets/screenshots/23-plans-view.png){ width="600" }
+  ![Plans view of the Planship app showing a list of plans along with the details of the selected plan named 'Personal'](../assets/screenshots/23-plans-view.png){ width="600" }
   <figcaption>Defining plans and entitlements in the Planship Console</figcaption>
 </figure>
 
 ## Step 2: Integrate Planship into your product code
 
-With your levers, plans, and entitlements defined in Planship, it's time to integrate your product with the [Planship API](/main-api/reference) to do the following:
+With your levers, plans, and entitlements defined in Planship, it's time to integrate your product with the [Planship API](../main-api/reference.md) to do the following:
 
-- [Register your customers](customers)
-- [Manage their subscriptions](subscriptions)
-- [Retrieve their entitlements](entitlements)
-- [Report metered usage](usage)
+- [Register your customers](customers.md)
+- [Manage their subscriptions](subscriptions.md)
+- [Retrieve their entitlements](entitlements.md)
+- [Report metered usage](usage.md)
 
 
 ### Languages and frameworks
@@ -66,10 +66,10 @@ If the frontend framework that you use doesn't have a dedicated Planship SDK yet
 
 ### Authentication and security
 
-The Planship API uses token-based authentication where access tokens are obtained via an [OAuth2 Client Credentials flow](https://oauth.net/2/grant-types/client-credentials/). The credentials consist of a client ID and secret pair that is exchanged for a token that grants access to the resources within an organization. Client ID and secret pairs are managed on the [organization](/concepts/products#organizations) level by organization admins and collaborators. You can find them in the Planship console under your organization.
+The Planship API uses token-based authentication where access tokens are obtained via an [OAuth2 Client Credentials flow](https://oauth.net/2/grant-types/client-credentials/). The credentials consist of a client ID and secret pair that is exchanged for a token that grants access to the resources within an organization. Client ID and secret pairs are managed on the [organization](../concepts/products.md#organizations) level by organization admins and collaborators. You can find them in the Planship console under your organization.
 
 <figure markdown="span">
-  ![Organization view of the Planship app showing a list of products and credentials](/assets/screenshots/24-org-credentials.png){ width="600" }
+  ![Organization view of the Planship app showing a list of products and credentials](../assets/screenshots/24-org-credentials.png){ width="600" }
   <figcaption>Managing products and credentials</figcaption>
 </figure>
 

--- a/docs/integration/subscriptions.md
+++ b/docs/integration/subscriptions.md
@@ -1,4 +1,4 @@
-Once a customer is [successfully registered with Planship](/integration/customers), you can subscribe them to a [Planship plan](/concepts/plans) by creating a new subscription for them using their ID and the slug of the desired plan.
+Once a customer is [successfully registered with Planship](customers.md), you can subscribe them to a [Planship plan](../concepts/plans.md) by creating a new subscription for them using their ID and the slug of the desired plan.
 
 === "JavaScript"
 
@@ -37,7 +37,7 @@ Once a customer is [successfully registered with Planship](/integration/customer
     ```
 
 !!!info
-    The *customer ID* can be the Planship-generated customer ID or your own ID provided to Planship as an [alternative ID](/integration/customers#using-your-own-customer-id).
+    The *customer ID* can be the Planship-generated customer ID or your own ID provided to Planship as an [alternative ID](customers.md#using-your-own-customer-id).
 
 The returned `subscription` object contains a subscription `id`, which is required when managing and modifying subscriptions. However, unlike customer IDs, subscription IDs don't need to be persisted in your product database as you can retrieve them programatically for a customer.
 
@@ -123,7 +123,7 @@ When a customer upgrades their plan, you may want to apply this change immediate
     )
     ```
 
-The same operation can be used when customers downgrade their subscriptions with an immediate effect (usually accompanied by a refund). However, downgrades are often processed at the end of a subscription period. This way, customers continue to have access to all of the product resources (like [features](/concepts/feature-levers) and/or [usage limits](/concepts/metered-levers)) they already paid for. To accomplish this, change the subscription's renew plan instead.
+The same operation can be used when customers downgrade their subscriptions with an immediate effect (usually accompanied by a refund). However, downgrades are often processed at the end of a subscription period. This way, customers continue to have access to all of the product resources (like [features](../concepts/feature-levers.md) and/or [usage limits](../concepts/metered-levers.md)) they already paid for. To accomplish this, change the subscription's renew plan instead.
 
 === "JavaScript"
 
@@ -257,7 +257,7 @@ If your plans support team subscriptions, instead of creating a new subscription
 
 Please note that this operation requires two customer IDs:
 
- - ID of an existing subscription customer to execute the operation, has to be an [administrator](/concepts/plans#subscription-administrators) of the subscription with a given ID
+ - ID of an existing subscription customer to execute the operation, has to be an [administrator](../concepts/plans.md#subscription-administrators) of the subscription with a given ID
  - ID of a customer to be added to the subscription with a given ID
 
 

--- a/docs/integration/usage.md
+++ b/docs/integration/usage.md
@@ -1,4 +1,4 @@
-If metered usage is a pricing dimension of your product and you've defined one or more [metered levers](/concepts/metered-levers), you will likely need to report customer usage to Planship. Metered usage is reported for a [*metering ID*](/concepts/metered-levers#metering-id), which is associated with one or more metered levers.
+If metered usage is a pricing dimension of your product and you've defined one or more [metered levers](../concepts/metered-levers.md), you will likely need to report customer usage to Planship. Metered usage is reported for a [*metering ID*](../concepts/metered-levers.md#metering-id), which is associated with one or more metered levers.
 
 === "JavaScript"
 
@@ -44,7 +44,7 @@ Every time usage is reported, Planship creates a metering record for traceabilit
 
 ### Reporting bucketed usage
 
-If your product defines usage levers that take advantage of *usage per bucket* or *unique buckets* [aggregation formulas](/concepts/metered-levers#formula), you will want to include a *bucket* identifier when reporting usage to Planship.
+If your product defines usage levers that take advantage of *usage per bucket* or *unique buckets* [aggregation formulas](../concepts/metered-levers.md#formula), you will want to include a *bucket* identifier when reporting usage to Planship.
 
 === "JavaScript"
 
@@ -94,7 +94,7 @@ The specified bucket value becomes part of the metering record and is used by Pl
 
 ## Check current usage
 
-While the remaining usage is returned as part of a customer's [entitlements](/integration/entitlements), you may want to retrieve the actual, current customer usage for a given metered usage lever.
+While the remaining usage is returned as part of a customer's [entitlements](entitlements.md), you may want to retrieve the actual, current customer usage for a given metered usage lever.
 
 === "JavaScript"
 


### PR DESCRIPTION
This PR changes absolute links to relative links (with file extensions) as per mkdocs best practices.