### PR TITLE
Make Stripe how to guide visible

### DIFF
--- a/docs/howtos/use-planship-with-stripe.md
+++ b/docs/howtos/use-planship-with-stripe.md
@@ -1,6 +1,6 @@
 # Using Planship with Stripe
 
-In this guide, we'll walk through how to use Planship with [Stripe](https://stripe.com) using the [Planship app for Stripe]. Let's get started.
+In this guide, we'll walk through how to use Planship with [Stripe](https://stripe.com) using the [Planship app for Stripe](https://marketplace.stripe.com/apps/planship). Let's get started.
 
 ## Why should I use Planship with Stripe?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
       - Customers: concepts/customers.md
     - How to:
       - Define a product in Planship: howtos/console-step-by-step.md
-      # - Use Stripe with Planship: howtos/use-planship-with-stripe.md
+      - Use Stripe with Planship: howtos/use-planship-with-stripe.md
   - Reference:
     - REST API reference: main-api/reference.md
 theme:


### PR DESCRIPTION
This PR, when merged, will make the Stripe how to guide visible in docs navigation. The guide itself now contains a correct link to the Planship app in Stripe marketplace.